### PR TITLE
Task scheduler

### DIFF
--- a/CronoLog/Controllers/TimedController.cs
+++ b/CronoLog/Controllers/TimedController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
@@ -18,75 +19,40 @@ namespace CronoLog.Controllers
     [EnableCors("TrelloHostPolicy")]
     public class TimedController : ControllerBase
     {
-        public TimedController()
+        private readonly MongoClient DbClient;
+        public TimedController([FromServices] MongoClient dbClient)
         {
+            DbClient = dbClient;
         }
 
-        public static async void SetEndTime(MongoClient dbClient)
+        [HttpGet("pause-cards")]
+        public async Task<IActionResult> PauseCards()
         {
-            TimedController.NoSleep();
+            Console.WriteLine("Pausando cartões ...");
+            Stopwatch sw = new();
+            sw.Start();
+            var cardsCollection = DatabaseUtils.CardsCollection(DbClient);
+            var cards = await cardsCollection.Find(Builders<TrelloCard>.Filter.Empty).ToListAsync();
 
-            bool running = true;
-            DateTime doWhen = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, 2, 55, 0);
-            if (doWhen.CompareTo(DateTime.UtcNow) < 0)
+            foreach (var card in cards)
             {
-                doWhen = doWhen.AddDays(1);
-            }
-            Console.WriteLine($"Cartões em excecução serão pausados automaticamente em: {doWhen.ToLongDateString()} {doWhen.ToLongTimeString()} UTC");
-            while (running)
-            {
-                DateTime now = DateTime.Now;
-                TimeSpan countDown = doWhen - now;
-
-                await Task.Delay(countDown);
-                Console.WriteLine("Pausando cartões... ");
-
-                var cardsCollection = DatabaseUtils.CardsCollection(dbClient);
-                var boardsCollection = DatabaseUtils.BoardsCollection(dbClient);
-                var cards = await cardsCollection.Find(Builders<TrelloCard>.Filter.Empty).ToListAsync();
-
-                foreach (var card in cards)
+                if (card.Timers.Count > 0)
                 {
-                    if (card.Timers.Count > 0)
+                    var lastTimer = card.Timers.FindLast((t) => t.State == TimeState.RUNNING);
+                    if (lastTimer != null)
                     {
-                        var lastTimer = card.Timers.FindLast((t) => t.State == TimeState.RUNNING);
-                        if (lastTimer != null)
-                        {
-                            var boardFilter = Builders<TrelloBoard>.Filter.Eq("Id", card.BoardId);
-                            var board = await boardsCollection.Find(boardFilter).FirstOrDefaultAsync();
-                            var httpClient = new HttpClient();
-                            CardData cardData = new CardData()
-                            {
-                                Board = new IdName(board.Id, board.Name),
-                                Member = new IdName("0", "Admin"),
-                                Card = new IdName(card.Id, card.Name),
-                                List = new IdName(card.CurrentList.Id, card.CurrentList.Name)
-                            };
-                            await httpClient.PostAsJsonAsync(ApiUtils.API_URL + "/cardtime/pause-stopwatch", cardData);
-                        }
+                        card.CurrentMember = new("0", "Admin");
+                        lastTimer.State = TimeState.PAUSED;
+                        lastTimer.End = DateTime.UtcNow;
+                        lastTimer.EndMember = card.CurrentMember;
+
+                        var cardFilter = Builders<TrelloCard>.Filter.Eq("Id", card.Id);
+                        await cardsCollection.FindOneAndReplaceAsync(cardFilter, card);
                     }
                 }
-                doWhen = doWhen.AddDays(1);
-                Console.WriteLine($"Cartões em excecução serão pausados automaticamente em: {doWhen.ToLongDateString()} {doWhen.ToLongTimeString()} UTC");
             }
-        }
-        public static async void NoSleep()
-        {
-            bool running = true;
-            DateTime taskTime = DateTime.UtcNow.AddMinutes(1);
-            Console.WriteLine($"NoSleep: {taskTime}");
-            while (running)
-            {
-                TimeSpan timeToWait = taskTime - DateTime.Now;
-                await Task.Delay(timeToWait);
-
-                var httpClient = new HttpClient();
-                Console.WriteLine($"Fazendo chamada /timed/shake ... {taskTime.ToLongTimeString()}");
-                await httpClient.GetAsync(ApiUtils.API_URL + "/Timed/shake");
-
-                taskTime = taskTime.AddMinutes(20);
-                Console.WriteLine($"Proxima chamada as {taskTime.ToLongTimeString()}");
-            }
+            sw.Stop();
+            return new JsonResult(new {TimeToPauseAllCards = sw.Elapsed});
         }
 
         [HttpGet("shake")]

--- a/CronoLog/Startup.cs
+++ b/CronoLog/Startup.cs
@@ -30,7 +30,6 @@ namespace CronoLog
             services.AddSingleton(provider =>
             {
                 var client = new MongoClient(Environment.GetEnvironmentVariable("MONGO_STRING"));
-                TimedController.SetEndTime(client);
                 return client;
             });
             services.AddCors(options =>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine as build
 
 WORKDIR /source
 COPY ./*.sln ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
 RUN apk add --no-cache curl
 WORKDIR /app
 COPY --from=build /app .
+
 COPY ping.sh ping.sh
 RUN chmod +x ping.sh
+COPY pause_cards.sh pause_cards.sh
+RUN chmod +x pause_cards.sh
+
 #ENTRYPOINT ["./CronoLog"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY . .
 RUN dotnet publish -c release -o /app --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0
-COPY ping.sh ping.sh
-RUN chmod +x ping.sh
 WORKDIR /app
 COPY --from=build /app .
-ENTRYPOINT ["./CronoLog"]
+COPY ping.sh ping.sh
+#RUN chmod +x ping.sh
+#ENTRYPOINT ["./CronoLog"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN dotnet restore
 
 COPY . .
 #RUN dotnet publish -c release -o /app --no-restore
-RUN dotnet publish -r linux-musl-x64 -p:PublishTrimmed=true -c release -o /app --self-contained --no-restore
+RUN dotnet publish -c release -o /app --no-restore
 
 #FROM mcr.microsoft.com/dotnet/aspnet:5.0
-FROM alpine:latest
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
 RUN apk add --no-cache curl
 WORKDIR /app
 COPY --from=build /app .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,14 @@ COPY ./CronoLog/*.csproj ./CronoLog/
 RUN dotnet restore
 
 COPY . .
-RUN dotnet publish -c release -o /app --no-restore
+#RUN dotnet publish -c release -o /app --no-restore
+RUN dotnet publish -r linux-musl-x64 -p:PublishTrimmed=true -c release -o /app --self-contained --no-restore
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+#FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM alpine:latest
+RUN apk add --no-cache curl
 WORKDIR /app
 COPY --from=build /app .
 COPY ping.sh ping.sh
-#RUN chmod +x ping.sh
+RUN chmod +x ping.sh
 #ENTRYPOINT ["./CronoLog"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY . .
 RUN dotnet publish -c release -o /app --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0
+COPY ping.sh ping.sh
+RUN chmod +x ping.sh
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["./CronoLog"]

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: ./CronoLog

--- a/pause_cards.sh
+++ b/pause_cards.sh
@@ -1,0 +1,1 @@
+curl $API_URL/timed/pause-cards

--- a/ping.sh
+++ b/ping.sh
@@ -1,0 +1,2 @@
+#/usr/bin/bash
+curl $API_URL/timed/shake

--- a/ping.sh
+++ b/ping.sh
@@ -1,2 +1,1 @@
-#/usr/bin/bash
 curl $API_URL/timed/shake


### PR DESCRIPTION
Remoção de métodos automáticos para pausar cartões em um horário especificado e fazer uma requisição para a própria aplicação para mantê-la executando. Esses métodos foram substituídos por rotas de API REST e devem ser chamados externamente, manualmente ou por alguma ferramenta de automação. Aplicação não é mais dependente de um estado inicial.